### PR TITLE
Change doc so it matches current Rancher 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 Rancher 2 UI driver for the [Hetzner Cloud](https://www.hetzner.de/cloud). For the Rancher 1 version check out the readme from the `v1.6` branch which you can find [here](https://github.com/mxschmitt/ui-driver-hetzner/blob/v1.6/README.md).
 
-## Using
+## Usage
 
-* Add a Machine Driver in Rancher 2 (`Global` -> `Custom Drivers` -> `Cluster Drivers`)
+* Add a Machine Driver in Rancher 2 (`Tools` -> `Drivers` -> `Node Drivers`)
 
 | Key | Value |
 | --- | ----- |


### PR DESCRIPTION
First I was confused since in Rancher 2.2.1 there are separate Cluster and Node Drivers. This is a node driver so I failed at first trying to add it as a cluster driver. I changed to doc accordingly.