### PR TITLE
feat: private network support

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -48,9 +48,10 @@ export default Ember.Component.extend(NodeDriver, {
       type: '%%DRIVERNAME%%Config',
       serverType: 'cx21', // 4 GB Ram
       serverLocation: 'nbg1', // Nuremberg
-      imageId: 1,
+      imageId: "168855", // ubuntu-18.04
       userData: '',
-      networks: []
+      networks: [],
+      usePrivateNetwork: false
     });
 
     set(this, 'model.%%DRIVERNAME%%Config', config);
@@ -64,6 +65,8 @@ export default Ember.Component.extend(NodeDriver, {
     if (!this.get('model.%%DRIVERNAME%%Config.networks')) {
       this.set('model.%%DRIVERNAME%%Config.networks', [])
     }
+
+    if(this.has)
 
     var errors = get(this, 'errors') || [];
     if (!get(this, 'model.name')) {

--- a/component/template.hbs
+++ b/component/template.hbs
@@ -11,7 +11,7 @@
       <div class="col-md-10">
         {{input type="password" value=model.hetznerConfig.apiToken classNames="form-control" placeholder="Your Hetzner Cloud API Token"}}
         <p class="help-block">Create it by switching into the
-          <a target="_blank" href="https://console.hetzner.cloud">Hetzner Cloud Console</a>, choosing a project, go to Access &rarr; Tokens and create a new API token there.</p>
+          <a target="_blank" rel="noopener noreferrer" href="https://console.hetzner.cloud">Hetzner Cloud Console</a>, choosing a project, go to Access &rarr; Tokens and create a new API token there.</p>
       </div>
     </div>
     {{top-errors errors=errors}}
@@ -71,14 +71,14 @@
     <div class="row form-group">
       <div class="col-md-2">
         <label class="form-control-static">
-          <a href="https://cloudinit.readthedocs.io/en/latest/topics/examples.html" target="_blank">Cloud-init Configuration</a> (optional)
+          <a href="https://cloudinit.readthedocs.io/en/latest/topics/examples.html" target="_blank" rel="noopener noreferrer">Cloud-init Configuration</a> (optional)
         </label>
       </div>
       <div class="col-md-10">
         <textarea value={{model.hetznerConfig.userData}} onchange={{action (mut model.hetznerConfig.userData) value="target.value" }} rows="3" style="width: 100%; resize: vertical"></textarea>
       </div>
       <div class="col-md-2">
-        <label class="form-control-static">Networks (Beta, optional. You have to create these Networks in the <a href="https://console.hetzner.cloud" target="_blank">Hetzner Cloud Console</a>)</label>
+        <label class="form-control-static">Networks (Beta, optional. You have to create these Networks in the <a href="https://console.hetzner.cloud" target="_blank" rel="noopener noreferrer">Hetzner Cloud Console</a>)</label>
       </div>
       <div class="col-md-4">
         <select class="form-control" onchange={{action 'modifyNetworks' }} multiple="true">
@@ -86,6 +86,13 @@
           <option value={{network.id}} selected={{array-includes model.hetznerConfig.networks network.id}}>{{network.name}} ({{network.ip_range}})</option>
           {{/each}}
         </select>
+      </div>
+      <div class="col-md-2">
+        <div class="checkbox">
+          <label class="acc-label">{{input type="checkbox" checked=model.hetznerConfig.usePrivateNetwork}}
+            Use private network (first private network which is attached will be used for communication)
+          </label>
+        </div>
       </div>
     </div>
      {{!-- This following contains the Name, Labels and Engine Options fields --}}
@@ -95,7 +102,7 @@
      {{!-- This component shows errors produced by validate() in the component --}}
      {{top-errors errors=errors}}
      {{!-- This component shows the Create and Cancel buttons --}}
-     {{save-cancel save="save" cancel="cancel"}}
+     {{save-cancel save="save" cancel=(action "cancel")}}
   </div>
   {{/if}}
 </section>


### PR DESCRIPTION
Changes:
- security: added `noopener noreferrer` to the outgoing links
- Set `ubuntu-18.04` as default image (Closes #82)
- Integrates support for private networks (Closes #44)
- Fix that Close was not working

Before
![image](https://user-images.githubusercontent.com/17984549/77830310-ebaf0300-7127-11ea-9528-e4128d202119.png)

After 

![image](https://user-images.githubusercontent.com/17984549/77830322-f8cbf200-7127-11ea-897e-7ca4d835e913.png)

(just temporary clusters, so no worries for sharing the IPs)

Thank you very much @ptr1120 for adding support in the upstream driver and investigating into that specific issue.