### PR TITLE
Add flag to force using public IP for SSH connections when enabling the private network

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -51,7 +51,8 @@ export default Ember.Component.extend(NodeDriver, {
       imageId: "168855", // ubuntu-18.04
       userData: '',
       networks: [],
-      usePrivateNetwork: false
+      usePrivateNetwork: false,
+      forcePublicSSH: false
     });
 
     set(this, 'model.%%DRIVERNAME%%Config', config);

--- a/component/template.hbs
+++ b/component/template.hbs
@@ -94,6 +94,13 @@
           </label>
         </div>
       </div>
+      <div class="col-md-2">
+        <div class="checkbox">
+          <label class="acc-label">{{input type="checkbox" checked=model.hetznerConfig.forcePublicSSH}}
+            Force use of public IP for SSH connections (allows separating Rancher and clusters into different Hetzner Cloud projects)
+          </label>
+        </div>
+      </div>
     </div>
      {{!-- This following contains the Name, Labels and Engine Options fields --}}
      {{form-name-description model=model nameRequired=true}}


### PR DESCRIPTION
Adds possibility to use private network first and have a global rancher instance, outside of the network scope.

Depending on: https://github.com/JonasProgrammer/docker-machine-driver-hetzner/pull/57