### PR TITLE
Add Firewall support

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -52,6 +52,7 @@ export default Ember.Component.extend(NodeDriver, {
       imageId: "168855", // ubuntu-18.04
       userData: '',
       networks: [],
+      firewalls: [],
       usePrivateNetwork: false,
       serverLabel: [''],
     });
@@ -66,6 +67,10 @@ export default Ember.Component.extend(NodeDriver, {
 
     if (!this.get('model.%%DRIVERNAME%%Config.networks')) {
       this.set('model.%%DRIVERNAME%%Config.networks', [])
+    }
+
+    if (!this.get('model.%%DRIVERNAME%%Config.firewalls')) {
+      this.set('model.%%DRIVERNAME%%Config.firewalls', [])
     }
 
     if (!this.get('model.%%DRIVERNAME%%Config.serverLabel')) {
@@ -95,7 +100,7 @@ export default Ember.Component.extend(NodeDriver, {
     getData() {
       this.set('gettingData', true);
       let that = this;
-      Promise.all([this.apiRequest('/v1/locations'), this.apiRequest('/v1/images'), this.apiRequest('/v1/server_types'), this.apiRequest('/v1/networks'), this.apiRequest('/v1/ssh_keys')]).then(function (responses) {
+      Promise.all([this.apiRequest('/v1/locations'), this.apiRequest('/v1/images'), this.apiRequest('/v1/server_types'), this.apiRequest('/v1/networks'), this.apiRequest('/v1/ssh_keys'), this.apiRequest('/v1/firewalls')]).then(function (responses) {
         that.setProperties({
           errors: [],
           needAPIToken: false,
@@ -116,6 +121,11 @@ export default Ember.Component.extend(NodeDriver, {
             .map(key => ({
               ...key,
               id: key.id.toString()
+            })),
+          firewallChoices: responses[5].firewalls
+            .map(firewall => ({
+              ...firewall,
+              id: firewall.id.toString()
             }))
         });
       }).catch(function (err) {
@@ -130,6 +140,10 @@ export default Ember.Component.extend(NodeDriver, {
     modifyNetworks: function (select) {
       let options = [...select.target.options].filter(o => o.selected).map(o => o.value)
       this.set('model.%%DRIVERNAME%%Config.networks', options);
+    },
+    modifyFirewalls: function (select) {
+      let options = [...select.target.options].filter(o => o.selected).map(o => o.value)
+      this.set('model.%%DRIVERNAME%%Config.firewalls', options);
     },
     setLabels: function(labels){
       let labels_list = labels.map(l => l.key + "=" + l.value);

--- a/component/template.hbs
+++ b/component/template.hbs
@@ -94,6 +94,16 @@
           </label>
         </div>
       </div>
+       <div class="col-md-2">
+        <label class="form-control-static">Firewalls (Beta, optional. You have to create these Firewalls in the <a href="https://console.hetzner.cloud" target="_blank" rel="noopener noreferrer">Hetzner Cloud Console</a>)</label>
+      </div>
+      <div class="col-md-4">
+        <select class="form-control" onchange={{action 'modifyFirewalls' }} multiple="true">
+          {{#each firewallChoices as |firewall|}}
+          <option value={{firewall.id}} selected={{array-includes model.hetznerConfig.firewalls firewall.id}}>{{firewall.name}}</option>
+          {{/each}}
+        </select>
+      </div>
       <div class="col-md-2">
         <label class="form-control-static">Additional SSH Keys</label>
       </div>


### PR DESCRIPTION
Solves #114

I tried to stick as close to the existing structure as possible.
Currently it only displays the list of firewalls to choose from by name, I'm happy for suggestions on how to maybe display the included in- and outbound rules aswell, since they are queryable by the api, but so far I haven't had a clean way in mind to do that.

As for the disclaimer on the label, I just copied it from the Networks label since it seems to apply here as well (BTW Networks doesn't seem to be in beta anymore).

Tested it and it works fine for me, firewalls are listed, and selected firewalls are applied to created machines.