### PR TITLE
Add support for Placement Groups

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -55,6 +55,7 @@ export default Ember.Component.extend(NodeDriver, {
       firewalls: [],
       usePrivateNetwork: false,
       serverLabel: [''],
+      placementGroup: ''
     });
 
     set(this, 'model.%%DRIVERNAME%%Config', config);
@@ -100,7 +101,7 @@ export default Ember.Component.extend(NodeDriver, {
     getData() {
       this.set('gettingData', true);
       let that = this;
-      Promise.all([this.apiRequest('/v1/locations'), this.apiRequest('/v1/images'), this.apiRequest('/v1/server_types'), this.apiRequest('/v1/networks'), this.apiRequest('/v1/ssh_keys'), this.apiRequest('/v1/firewalls')]).then(function (responses) {
+      Promise.all([this.apiRequest('/v1/locations'), this.apiRequest('/v1/images'), this.apiRequest('/v1/server_types'), this.apiRequest('/v1/networks'), this.apiRequest('/v1/ssh_keys'), this.apiRequest('/v1/firewalls'), this.apiRequest('/v1/placement_groups')]).then(function (responses) {
         that.setProperties({
           errors: [],
           needAPIToken: false,
@@ -126,7 +127,8 @@ export default Ember.Component.extend(NodeDriver, {
             .map(firewall => ({
               ...firewall,
               id: firewall.id.toString()
-            }))
+            })),
+          placementGroupChoices: responses[6].placement_groups
         });
       }).catch(function (err) {
         err.then(function (msg) {

--- a/component/template.hbs
+++ b/component/template.hbs
@@ -114,6 +114,15 @@
           {{/each}}
         </select>
       </div>
+      <div class="col-md-2">
+        <label class="form-control-static">Placement group</label>
+          <select class="form-control" onchange={{action (mut model.hetznerConfig.placementGroup) value="target.value" }}>
+            <option value="" selected="{{not model.hetznerConfig.placementGroup}}"></option>
+            {{#each placementGroupChoices as |placementGroup|}}
+              <option value="{{placementGroup.name}}" selected={{eq model.hetznerConfig.placementGroup placementGroup.name}}>{{placementGroup.name}} ({{placementGroup.type}})</option>
+            {{/each}}
+          </select>
+      </div>
     </div>
      {{!-- This following contains the Name, Labels and Engine Options fields --}}
      {{form-name-description model=model nameRequired=true}}


### PR DESCRIPTION
Implemented Placement Groups to solve #126 

Atm you will need to create the placement group in the cloud panel, to be able to select it. But it would be possible to implement a custom name input, for automatic creation.

Tested it, and it worked flawless with & without a placement group.

(docker-machine-driver-hetzner must be updated to 3.5.0, but not shure how readme changes are handled)