### PR TITLE
Added handling for image name only and placement group id values

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -49,6 +49,7 @@ export default Ember.Component.extend(NodeDriver, {
       additionalKey: [],
       serverType: 'cx21', // 4 GB Ram
       serverLocation: 'nbg1', // Nuremberg
+      image: '',
       imageId: "168855", // ubuntu-18.04
       userData: '',
       networks: [],

--- a/component/template.hbs
+++ b/component/template.hbs
@@ -53,11 +53,11 @@
       <div class="col-md-4">
         <select class="form-control" onchange={{action (mut model.hetznerConfig.imageId) value="target.value" }}>
           {{#each imageChoices as |choice|}}
-            <option value={{choice.id}} selected={{eq model.hetznerConfig.imageId choice.id}}>{{choice.description}}</option>
+            <option value={{choice.id}} selected={{or (eq model.hetznerConfig.imageId choice.id) (eq model.hetznerConfig.image choice.name)}}>{{choice.description}}</option>
           {{/each}}
         </select>
       </div>
-      <div class="col-md-2">
+      <div class="col-md-2"> 
         <label class="form-control-static">Size</label>
       </div>
       <div class="col-md-4">
@@ -119,7 +119,7 @@
           <select class="form-control" onchange={{action (mut model.hetznerConfig.placementGroup) value="target.value" }}>
             <option value="" selected="{{not model.hetznerConfig.placementGroup}}"></option>
             {{#each placementGroupChoices as |placementGroup|}}
-              <option value="{{placementGroup.name}}" selected={{eq model.hetznerConfig.placementGroup placementGroup.name}}>{{placementGroup.name}} ({{placementGroup.type}})</option>
+              <option value="{{placementGroup.name}}" selected={{or (eq model.hetznerConfig.placementGroup placementGroup.name) (eq model.hetznerConfig.placementGroup placementGroup.id)}}>{{placementGroup.name}} ({{placementGroup.type}})</option>
             {{/each}}
           </select>
       </div>


### PR DESCRIPTION
This PR enables the image and placement group select fields in the UI to show the correct selection if a node template was not created via UI and only an image name or placement group id was defined.

This is especially the case for node templates that have been deployed using the rancher2 terraform provider.

Related: https://github.com/rancher/terraform-provider-rancher2/pull/1162